### PR TITLE
Update packages to include digitemp package

### DIFF
--- a/openwrt/packages
+++ b/openwrt/packages
@@ -12,3 +12,4 @@ kmod-usb-serial-cp210x
 kmod-usb-acm
 kmod-pptp
 qos-scripts
+digitemp


### PR DESCRIPTION
digitemp package is missing in current repository but it is present in web interface, so if there is no issue with this package please include it.
