### PR TITLE
Update packages

### DIFF
--- a/openwrt/packages
+++ b/openwrt/packages
@@ -9,9 +9,12 @@ kmod-netem
 olsrd
 kmod-usb-serial
 kmod-usb-serial-cp210x
+kmod-usb-serial-ftdi
 kmod-usb-acm
 kmod-pptp
 qos-scripts
 ppp-mod-pptp
 iperf
 wpa-supplicant
+wpa-supplicant-mini
+nano


### PR DESCRIPTION
Please include these three packages.
kmod-usb-serial-ftdi - so you can connect arduino directly to usb port
nano - because it is more user friendly text editor than vi
wpa-supplicant-mini - is smaller version of of wpa-supplicant package
