### PR TITLE
additional packages

### DIFF
--- a/openwrt/packages
+++ b/openwrt/packages
@@ -70,3 +70,10 @@ kmod-input-core
 kmod-video-videobuf2
 mjpg-streamer
 lm4flash
+kmod-ath5k
+kmod-ledtrig-usbdev
+kmod-ltq-dsl-firmware-a-danube
+kmod-ltq-dsl-firmware-b-danube
+kmod-usb-dwc-otg
+libjson
+wpad-mini


### PR DESCRIPTION
Adding missing packages which are needed for successful build of lantiq (Siemens SX763) firmware image
