### PR TITLE
usb-modeswitch

### DIFF
--- a/openwrt/packages
+++ b/openwrt/packages
@@ -25,6 +25,7 @@ kmod-ppp
 ppp
 chat
 comgt
+usb-modeswitch
 kmod-pptp
 qos-scripts
 ppp-mod-pptp


### PR DESCRIPTION
usb-modeswitch was missing, and this is crucial package for 3g support