### PR TITLE
Add kmod-usb3 package

### DIFF
--- a/lede/packages
+++ b/lede/packages
@@ -103,6 +103,7 @@ kmod-usb-net-cdc-ncm
 kmod-usb-net-cdc-mbim
 kmod-usb-net-rndis
 kmod-usb2
+kmod-usb3
 kmod-usb-ohci
 kmod-usb-uhci
 mjpg-streamer

--- a/openwrt/packages
+++ b/openwrt/packages
@@ -107,6 +107,7 @@ kmod-usb-net-cdc-ncm
 kmod-usb-net-cdc-mbim
 kmod-usb-net-rndis
 kmod-usb2
+kmod-usb3
 kmod-usb-ohci
 kmod-usb-uhci
 mjpg-streamer


### PR DESCRIPTION
Add kmod-usb3 package to LEDE and OpenWRT since I am working on adding support for devices with USB 3.0 into Nodewatcher and it will be needed.