### PR TITLE
lede: Add master based branch 

### DIFF
--- a/docker/lede/builder-stage-1/master/ar71xx/Dockerfile
+++ b/docker/lede/builder-stage-1/master/ar71xx/Dockerfile
@@ -1,0 +1,27 @@
+
+########################################################################
+# WARNING: This is an automatically generated Dockerfile. DO NOT EDIT. #
+########################################################################
+
+FROM wlanslovenija/lede-buildsystem:master
+
+RUN chown builder:builder /buildsystem/build && \
+ sudo -E -u builder ./lede/scripts/configure-platform ar71xx && \
+ sudo -E -u builder ./lede/scripts/build-toolchain && \
+ sudo -E -u builder ./lede/scripts/build-imagebuilder && \
+ export version="$(cat /buildsystem/build/lede/package/base-files/files/etc/version)" && \
+ cd /buildsystem/build/release && \
+ mkdir -p /builder/imagebuilder && \
+ tar xf imagebuilder.tar.xz -C /builder/imagebuilder --strip-components 1 && \
+ mv packages /builder/packages && \
+ echo -n "{\"platform\": \"lede\", " > /builder/packages/metadata && \
+ echo -n "\"architecture\": \"ar71xx\", " >> /builder/packages/metadata && \
+ echo -n "\"version\": \"${version}\", " >> /builder/packages/metadata && \
+ echo -n "\"packages\": " >> /builder/packages/metadata && \
+ find /builder/packages -name Packages | xargs cat | /buildsystem/lede/tools/packages2json.py >> /builder/packages/metadata && \
+ echo "}" >> /builder/packages/metadata && \
+ cp /buildsystem/lede/docker/Dockerfile.runtime /builder/Dockerfile && \
+ { rm -rf /buildsystem 2>/dev/null || true; }
+
+WORKDIR /builder
+CMD tar cvzhf - .

--- a/docker/lede/builder-stage-1/master/ar71xx_mikrotik/Dockerfile
+++ b/docker/lede/builder-stage-1/master/ar71xx_mikrotik/Dockerfile
@@ -1,0 +1,27 @@
+
+########################################################################
+# WARNING: This is an automatically generated Dockerfile. DO NOT EDIT. #
+########################################################################
+
+FROM wlanslovenija/lede-buildsystem:master
+
+RUN chown builder:builder /buildsystem/build && \
+ sudo -E -u builder ./lede/scripts/configure-platform ar71xx_mikrotik && \
+ sudo -E -u builder ./lede/scripts/build-toolchain && \
+ sudo -E -u builder ./lede/scripts/build-imagebuilder && \
+ export version="$(cat /buildsystem/build/lede/package/base-files/files/etc/version)" && \
+ cd /buildsystem/build/release && \
+ mkdir -p /builder/imagebuilder && \
+ tar xf imagebuilder.tar.xz -C /builder/imagebuilder --strip-components 1 && \
+ mv packages /builder/packages && \
+ echo -n "{\"platform\": \"lede\", " > /builder/packages/metadata && \
+ echo -n "\"architecture\": \"ar71xx_mikrotik\", " >> /builder/packages/metadata && \
+ echo -n "\"version\": \"${version}\", " >> /builder/packages/metadata && \
+ echo -n "\"packages\": " >> /builder/packages/metadata && \
+ find /builder/packages -name Packages | xargs cat | /buildsystem/lede/tools/packages2json.py >> /builder/packages/metadata && \
+ echo "}" >> /builder/packages/metadata && \
+ cp /buildsystem/lede/docker/Dockerfile.runtime /builder/Dockerfile && \
+ { rm -rf /buildsystem 2>/dev/null || true; }
+
+WORKDIR /builder
+CMD tar cvzhf - .

--- a/docker/lede/builder-stage-1/master/atheros/Dockerfile
+++ b/docker/lede/builder-stage-1/master/atheros/Dockerfile
@@ -1,0 +1,27 @@
+
+########################################################################
+# WARNING: This is an automatically generated Dockerfile. DO NOT EDIT. #
+########################################################################
+
+FROM wlanslovenija/lede-buildsystem:master
+
+RUN chown builder:builder /buildsystem/build && \
+ sudo -E -u builder ./lede/scripts/configure-platform atheros && \
+ sudo -E -u builder ./lede/scripts/build-toolchain && \
+ sudo -E -u builder ./lede/scripts/build-imagebuilder && \
+ export version="$(cat /buildsystem/build/lede/package/base-files/files/etc/version)" && \
+ cd /buildsystem/build/release && \
+ mkdir -p /builder/imagebuilder && \
+ tar xf imagebuilder.tar.xz -C /builder/imagebuilder --strip-components 1 && \
+ mv packages /builder/packages && \
+ echo -n "{\"platform\": \"lede\", " > /builder/packages/metadata && \
+ echo -n "\"architecture\": \"atheros\", " >> /builder/packages/metadata && \
+ echo -n "\"version\": \"${version}\", " >> /builder/packages/metadata && \
+ echo -n "\"packages\": " >> /builder/packages/metadata && \
+ find /builder/packages -name Packages | xargs cat | /buildsystem/lede/tools/packages2json.py >> /builder/packages/metadata && \
+ echo "}" >> /builder/packages/metadata && \
+ cp /buildsystem/lede/docker/Dockerfile.runtime /builder/Dockerfile && \
+ { rm -rf /buildsystem 2>/dev/null || true; }
+
+WORKDIR /builder
+CMD tar cvzhf - .

--- a/docker/lede/builder-stage-1/master/brcm2708/Dockerfile
+++ b/docker/lede/builder-stage-1/master/brcm2708/Dockerfile
@@ -1,0 +1,27 @@
+
+########################################################################
+# WARNING: This is an automatically generated Dockerfile. DO NOT EDIT. #
+########################################################################
+
+FROM wlanslovenija/lede-buildsystem:master
+
+RUN chown builder:builder /buildsystem/build && \
+ sudo -E -u builder ./lede/scripts/configure-platform brcm2708 && \
+ sudo -E -u builder ./lede/scripts/build-toolchain && \
+ sudo -E -u builder ./lede/scripts/build-imagebuilder && \
+ export version="$(cat /buildsystem/build/lede/package/base-files/files/etc/version)" && \
+ cd /buildsystem/build/release && \
+ mkdir -p /builder/imagebuilder && \
+ tar xf imagebuilder.tar.xz -C /builder/imagebuilder --strip-components 1 && \
+ mv packages /builder/packages && \
+ echo -n "{\"platform\": \"lede\", " > /builder/packages/metadata && \
+ echo -n "\"architecture\": \"brcm2708\", " >> /builder/packages/metadata && \
+ echo -n "\"version\": \"${version}\", " >> /builder/packages/metadata && \
+ echo -n "\"packages\": " >> /builder/packages/metadata && \
+ find /builder/packages -name Packages | xargs cat | /buildsystem/lede/tools/packages2json.py >> /builder/packages/metadata && \
+ echo "}" >> /builder/packages/metadata && \
+ cp /buildsystem/lede/docker/Dockerfile.runtime /builder/Dockerfile && \
+ { rm -rf /buildsystem 2>/dev/null || true; }
+
+WORKDIR /builder
+CMD tar cvzhf - .

--- a/docker/lede/builder-stage-1/master/lantiq/Dockerfile
+++ b/docker/lede/builder-stage-1/master/lantiq/Dockerfile
@@ -1,0 +1,27 @@
+
+########################################################################
+# WARNING: This is an automatically generated Dockerfile. DO NOT EDIT. #
+########################################################################
+
+FROM wlanslovenija/lede-buildsystem:master
+
+RUN chown builder:builder /buildsystem/build && \
+ sudo -E -u builder ./lede/scripts/configure-platform lantiq && \
+ sudo -E -u builder ./lede/scripts/build-toolchain && \
+ sudo -E -u builder ./lede/scripts/build-imagebuilder && \
+ export version="$(cat /buildsystem/build/lede/package/base-files/files/etc/version)" && \
+ cd /buildsystem/build/release && \
+ mkdir -p /builder/imagebuilder && \
+ tar xf imagebuilder.tar.xz -C /builder/imagebuilder --strip-components 1 && \
+ mv packages /builder/packages && \
+ echo -n "{\"platform\": \"lede\", " > /builder/packages/metadata && \
+ echo -n "\"architecture\": \"lantiq\", " >> /builder/packages/metadata && \
+ echo -n "\"version\": \"${version}\", " >> /builder/packages/metadata && \
+ echo -n "\"packages\": " >> /builder/packages/metadata && \
+ find /builder/packages -name Packages | xargs cat | /buildsystem/lede/tools/packages2json.py >> /builder/packages/metadata && \
+ echo "}" >> /builder/packages/metadata && \
+ cp /buildsystem/lede/docker/Dockerfile.runtime /builder/Dockerfile && \
+ { rm -rf /buildsystem 2>/dev/null || true; }
+
+WORKDIR /builder
+CMD tar cvzhf - .

--- a/docker/lede/builder-stage-1/master/ramips_mt7620/Dockerfile
+++ b/docker/lede/builder-stage-1/master/ramips_mt7620/Dockerfile
@@ -1,0 +1,27 @@
+
+########################################################################
+# WARNING: This is an automatically generated Dockerfile. DO NOT EDIT. #
+########################################################################
+
+FROM wlanslovenija/lede-buildsystem:master
+
+RUN chown builder:builder /buildsystem/build && \
+ sudo -E -u builder ./lede/scripts/configure-platform ramips_mt7620 && \
+ sudo -E -u builder ./lede/scripts/build-toolchain && \
+ sudo -E -u builder ./lede/scripts/build-imagebuilder && \
+ export version="$(cat /buildsystem/build/lede/package/base-files/files/etc/version)" && \
+ cd /buildsystem/build/release && \
+ mkdir -p /builder/imagebuilder && \
+ tar xf imagebuilder.tar.xz -C /builder/imagebuilder --strip-components 1 && \
+ mv packages /builder/packages && \
+ echo -n "{\"platform\": \"lede\", " > /builder/packages/metadata && \
+ echo -n "\"architecture\": \"ramips_mt7620\", " >> /builder/packages/metadata && \
+ echo -n "\"version\": \"${version}\", " >> /builder/packages/metadata && \
+ echo -n "\"packages\": " >> /builder/packages/metadata && \
+ find /builder/packages -name Packages | xargs cat | /buildsystem/lede/tools/packages2json.py >> /builder/packages/metadata && \
+ echo "}" >> /builder/packages/metadata && \
+ cp /buildsystem/lede/docker/Dockerfile.runtime /builder/Dockerfile && \
+ { rm -rf /buildsystem 2>/dev/null || true; }
+
+WORKDIR /builder
+CMD tar cvzhf - .

--- a/docker/lede/builder-stage-1/master/ramips_mt7621/Dockerfile
+++ b/docker/lede/builder-stage-1/master/ramips_mt7621/Dockerfile
@@ -1,0 +1,27 @@
+
+########################################################################
+# WARNING: This is an automatically generated Dockerfile. DO NOT EDIT. #
+########################################################################
+
+FROM wlanslovenija/lede-buildsystem:master
+
+RUN chown builder:builder /buildsystem/build && \
+ sudo -E -u builder ./lede/scripts/configure-platform ramips_mt7621 && \
+ sudo -E -u builder ./lede/scripts/build-toolchain && \
+ sudo -E -u builder ./lede/scripts/build-imagebuilder && \
+ export version="$(cat /buildsystem/build/lede/package/base-files/files/etc/version)" && \
+ cd /buildsystem/build/release && \
+ mkdir -p /builder/imagebuilder && \
+ tar xf imagebuilder.tar.xz -C /builder/imagebuilder --strip-components 1 && \
+ mv packages /builder/packages && \
+ echo -n "{\"platform\": \"lede\", " > /builder/packages/metadata && \
+ echo -n "\"architecture\": \"ramips_mt7621\", " >> /builder/packages/metadata && \
+ echo -n "\"version\": \"${version}\", " >> /builder/packages/metadata && \
+ echo -n "\"packages\": " >> /builder/packages/metadata && \
+ find /builder/packages -name Packages | xargs cat | /buildsystem/lede/tools/packages2json.py >> /builder/packages/metadata && \
+ echo "}" >> /builder/packages/metadata && \
+ cp /buildsystem/lede/docker/Dockerfile.runtime /builder/Dockerfile && \
+ { rm -rf /buildsystem 2>/dev/null || true; }
+
+WORKDIR /builder
+CMD tar cvzhf - .

--- a/docker/lede/builder-stage-1/master/ramips_mt7628/Dockerfile
+++ b/docker/lede/builder-stage-1/master/ramips_mt7628/Dockerfile
@@ -1,0 +1,27 @@
+
+########################################################################
+# WARNING: This is an automatically generated Dockerfile. DO NOT EDIT. #
+########################################################################
+
+FROM wlanslovenija/lede-buildsystem:master
+
+RUN chown builder:builder /buildsystem/build && \
+ sudo -E -u builder ./lede/scripts/configure-platform ramips_mt7628 && \
+ sudo -E -u builder ./lede/scripts/build-toolchain && \
+ sudo -E -u builder ./lede/scripts/build-imagebuilder && \
+ export version="$(cat /buildsystem/build/lede/package/base-files/files/etc/version)" && \
+ cd /buildsystem/build/release && \
+ mkdir -p /builder/imagebuilder && \
+ tar xf imagebuilder.tar.xz -C /builder/imagebuilder --strip-components 1 && \
+ mv packages /builder/packages && \
+ echo -n "{\"platform\": \"lede\", " > /builder/packages/metadata && \
+ echo -n "\"architecture\": \"ramips_mt7628\", " >> /builder/packages/metadata && \
+ echo -n "\"version\": \"${version}\", " >> /builder/packages/metadata && \
+ echo -n "\"packages\": " >> /builder/packages/metadata && \
+ find /builder/packages -name Packages | xargs cat | /buildsystem/lede/tools/packages2json.py >> /builder/packages/metadata && \
+ echo "}" >> /builder/packages/metadata && \
+ cp /buildsystem/lede/docker/Dockerfile.runtime /builder/Dockerfile && \
+ { rm -rf /buildsystem 2>/dev/null || true; }
+
+WORKDIR /builder
+CMD tar cvzhf - .

--- a/docker/lede/builder-stage-1/master/ramips_mt76x8/Dockerfile
+++ b/docker/lede/builder-stage-1/master/ramips_mt76x8/Dockerfile
@@ -3,10 +3,10 @@
 # WARNING: This is an automatically generated Dockerfile. DO NOT EDIT. #
 ########################################################################
 
-FROM wlanslovenija/lede-buildsystem:v17.01.4
+FROM wlanslovenija/lede-buildsystem:master
 
 RUN chown builder:builder /buildsystem/build && \
- sudo -E -u builder ./lede/scripts/configure-platform ramips_mt7628 && \
+ sudo -E -u builder ./lede/scripts/configure-platform ramips_mt76x8 && \
  sudo -E -u builder ./lede/scripts/build-toolchain && \
  sudo -E -u builder ./lede/scripts/build-imagebuilder && \
  export version="$(cat /buildsystem/build/lede/package/base-files/files/etc/version)" && \
@@ -15,7 +15,7 @@ RUN chown builder:builder /buildsystem/build && \
  tar xf imagebuilder.tar.xz -C /builder/imagebuilder --strip-components 1 && \
  mv packages /builder/packages && \
  echo -n "{\"platform\": \"lede\", " > /builder/packages/metadata && \
- echo -n "\"architecture\": \"ramips_mt7628\", " >> /builder/packages/metadata && \
+ echo -n "\"architecture\": \"ramips_mt76x8\", " >> /builder/packages/metadata && \
  echo -n "\"version\": \"${version}\", " >> /builder/packages/metadata && \
  echo -n "\"packages\": " >> /builder/packages/metadata && \
  find /builder/packages -name Packages | xargs cat | /buildsystem/lede/tools/packages2json.py >> /builder/packages/metadata && \

--- a/docker/lede/builder-stage-1/master/ramips_rt305x/Dockerfile
+++ b/docker/lede/builder-stage-1/master/ramips_rt305x/Dockerfile
@@ -1,0 +1,27 @@
+
+########################################################################
+# WARNING: This is an automatically generated Dockerfile. DO NOT EDIT. #
+########################################################################
+
+FROM wlanslovenija/lede-buildsystem:master
+
+RUN chown builder:builder /buildsystem/build && \
+ sudo -E -u builder ./lede/scripts/configure-platform ramips_rt305x && \
+ sudo -E -u builder ./lede/scripts/build-toolchain && \
+ sudo -E -u builder ./lede/scripts/build-imagebuilder && \
+ export version="$(cat /buildsystem/build/lede/package/base-files/files/etc/version)" && \
+ cd /buildsystem/build/release && \
+ mkdir -p /builder/imagebuilder && \
+ tar xf imagebuilder.tar.xz -C /builder/imagebuilder --strip-components 1 && \
+ mv packages /builder/packages && \
+ echo -n "{\"platform\": \"lede\", " > /builder/packages/metadata && \
+ echo -n "\"architecture\": \"ramips_rt305x\", " >> /builder/packages/metadata && \
+ echo -n "\"version\": \"${version}\", " >> /builder/packages/metadata && \
+ echo -n "\"packages\": " >> /builder/packages/metadata && \
+ find /builder/packages -name Packages | xargs cat | /buildsystem/lede/tools/packages2json.py >> /builder/packages/metadata && \
+ echo "}" >> /builder/packages/metadata && \
+ cp /buildsystem/lede/docker/Dockerfile.runtime /builder/Dockerfile && \
+ { rm -rf /buildsystem 2>/dev/null || true; }
+
+WORKDIR /builder
+CMD tar cvzhf - .

--- a/docker/lede/builder-stage-1/master/x86_64/Dockerfile
+++ b/docker/lede/builder-stage-1/master/x86_64/Dockerfile
@@ -1,0 +1,27 @@
+
+########################################################################
+# WARNING: This is an automatically generated Dockerfile. DO NOT EDIT. #
+########################################################################
+
+FROM wlanslovenija/lede-buildsystem:master
+
+RUN chown builder:builder /buildsystem/build && \
+ sudo -E -u builder ./lede/scripts/configure-platform x86_64 && \
+ sudo -E -u builder ./lede/scripts/build-toolchain && \
+ sudo -E -u builder ./lede/scripts/build-imagebuilder && \
+ export version="$(cat /buildsystem/build/lede/package/base-files/files/etc/version)" && \
+ cd /buildsystem/build/release && \
+ mkdir -p /builder/imagebuilder && \
+ tar xf imagebuilder.tar.xz -C /builder/imagebuilder --strip-components 1 && \
+ mv packages /builder/packages && \
+ echo -n "{\"platform\": \"lede\", " > /builder/packages/metadata && \
+ echo -n "\"architecture\": \"x86_64\", " >> /builder/packages/metadata && \
+ echo -n "\"version\": \"${version}\", " >> /builder/packages/metadata && \
+ echo -n "\"packages\": " >> /builder/packages/metadata && \
+ find /builder/packages -name Packages | xargs cat | /buildsystem/lede/tools/packages2json.py >> /builder/packages/metadata && \
+ echo "}" >> /builder/packages/metadata && \
+ cp /buildsystem/lede/docker/Dockerfile.runtime /builder/Dockerfile && \
+ { rm -rf /buildsystem 2>/dev/null || true; }
+
+WORKDIR /builder
+CMD tar cvzhf - .

--- a/docker/lede/builder-stage-1/v17.01.4/ramips_mt76x8/Dockerfile
+++ b/docker/lede/builder-stage-1/v17.01.4/ramips_mt76x8/Dockerfile
@@ -3,10 +3,10 @@
 # WARNING: This is an automatically generated Dockerfile. DO NOT EDIT. #
 ########################################################################
 
-FROM wlanslovenija/lede-buildsystem:master
+FROM wlanslovenija/lede-buildsystem:v17.01.4
 
 RUN chown builder:builder /buildsystem/build && \
- sudo -E -u builder ./lede/scripts/configure-platform ramips_mt7628 && \
+ sudo -E -u builder ./lede/scripts/configure-platform ramips_mt76x8 && \
  sudo -E -u builder ./lede/scripts/build-toolchain && \
  sudo -E -u builder ./lede/scripts/build-imagebuilder && \
  export version="$(cat /buildsystem/build/lede/package/base-files/files/etc/version)" && \
@@ -15,7 +15,7 @@ RUN chown builder:builder /buildsystem/build && \
  tar xf imagebuilder.tar.xz -C /builder/imagebuilder --strip-components 1 && \
  mv packages /builder/packages && \
  echo -n "{\"platform\": \"lede\", " > /builder/packages/metadata && \
- echo -n "\"architecture\": \"ramips_mt7628\", " >> /builder/packages/metadata && \
+ echo -n "\"architecture\": \"ramips_mt76x8\", " >> /builder/packages/metadata && \
  echo -n "\"version\": \"${version}\", " >> /builder/packages/metadata && \
  echo -n "\"packages\": " >> /builder/packages/metadata && \
  find /builder/packages -name Packages | xargs cat | /buildsystem/lede/tools/packages2json.py >> /builder/packages/metadata && \

--- a/docker/lede/buildsystem/master/Dockerfile
+++ b/docker/lede/buildsystem/master/Dockerfile
@@ -5,6 +5,6 @@
 
 FROM wlanslovenija/firmware-base
 
-RUN ./lede/scripts/prepare master source.git 98fb380d8855f7d6b94f3be791331adaa3d88a2a && \
+RUN ./lede/scripts/prepare master source.git 20c349f68ca108d8b20363efbf5fa698e8446009 && \
  rm -rf .git && \
  chown -R builder:builder build

--- a/docker/lede/buildsystem/master/Dockerfile
+++ b/docker/lede/buildsystem/master/Dockerfile
@@ -1,0 +1,10 @@
+
+########################################################################
+# WARNING: This is an automatically generated Dockerfile. DO NOT EDIT. #
+########################################################################
+
+FROM wlanslovenija/firmware-base
+
+RUN ./lede/scripts/prepare master source.git 98fb380d8855f7d6b94f3be791331adaa3d88a2a && \
+ rm -rf .git && \
+ chown -R builder:builder build

--- a/lede/architectures
+++ b/lede/architectures
@@ -7,4 +7,4 @@ brcm2708
 ramips_rt305x
 ramips_mt7620
 ramips_mt7621
-ramips_mt7628
+ramips_mt76x8

--- a/lede/branches
+++ b/lede/branches
@@ -1,1 +1,2 @@
 v17.01.4:source.git:444add156f2a6d92fc15005c5ade2208a978966c:17_01_4
+master:source.git:98fb380d8855f7d6b94f3be791331adaa3d88a2a:master

--- a/lede/branches
+++ b/lede/branches
@@ -1,2 +1,2 @@
 v17.01.4:source.git:444add156f2a6d92fc15005c5ade2208a978966c:17_01_4
-master:source.git:98fb380d8855f7d6b94f3be791331adaa3d88a2a:master
+master:source.git:20c349f68ca108d8b20363efbf5fa698e8446009:master

--- a/lede/configs/ramips_mt7628
+++ b/lede/configs/ramips_mt7628
@@ -1,2 +1,0 @@
-CONFIG_TARGET_ramips=y
-CONFIG_TARGET_ramips_mt7628=y

--- a/lede/configs/ramips_mt76x8
+++ b/lede/configs/ramips_mt76x8
@@ -1,0 +1,2 @@
+CONFIG_TARGET_ramips=y
+CONFIG_TARGET_ramips_mt76x8=y

--- a/lede/feeds/master
+++ b/lede/feeds/master
@@ -1,2 +1,2 @@
-src-git lede https://git.lede-project.org/feed/packages.git^0230af3b20274597d5258c8f425a6883d1fa3d2a
+src-git lede https://git.lede-project.org/feed/packages.git^fe63607e8802de6347120910e1539240876c94f9
 src-git routing git://github.com/wlanslovenija/openwrt-routing-packages.git

--- a/lede/feeds/master
+++ b/lede/feeds/master
@@ -1,0 +1,2 @@
+src-git lede https://git.lede-project.org/feed/packages.git^0230af3b20274597d5258c8f425a6883d1fa3d2a
+src-git routing git://github.com/wlanslovenija/openwrt-routing-packages.git

--- a/lede/packages
+++ b/lede/packages
@@ -124,3 +124,5 @@ kmod-gre
 kmod-ath10k
 ath10k-firmware-qca988x
 snmpd
+rbcfg
+vnstat

--- a/lede/patches/master/006-tplink-writable-uboot.patch
+++ b/lede/patches/master/006-tplink-writable-uboot.patch
@@ -1,0 +1,12 @@
+Index: target/linux/ar71xx/files/drivers/mtd/tplinkpart.c
+===================================================================
+--- target/linux/ar71xx/files/drivers/mtd/tplinkpart.c.orig	2014-11-14 14:14:31.657150281 +0100
++++ target/linux/ar71xx/files/drivers/mtd/tplinkpart.c	2014-11-14 14:14:42.785149863 +0100
+@@ -149,7 +149,6 @@
+ 	parts[0].name = "u-boot";
+ 	parts[0].offset = 0;
+ 	parts[0].size = offset;
+-	parts[0].mask_flags = MTD_WRITEABLE;
+ 
+ 	parts[1].name = "kernel";
+ 	parts[1].offset = offset;

--- a/lede/patches/master/series
+++ b/lede/patches/master/series
@@ -1,0 +1,1 @@
+006-tplink-writable-uboot.patch -p0

--- a/lede/scripts/build-imagebuilder
+++ b/lede/scripts/build-imagebuilder
@@ -24,7 +24,7 @@ rm -rf ${release_dir}
 mkdir -p ${release_dir}
 
 echo "Extracting the imagebuilder..."
-mv ${checkout_dir}/bin/targets/*/*/lede-imagebuilder-*.tar.xz ${release_dir}/imagebuilder.tar.xz
+mv ${checkout_dir}/bin/targets/*/*/openwrt-imagebuilder-*.tar.xz ${release_dir}/imagebuilder.tar.xz
 
 echo "Extracting packages..."
 cd ${checkout_dir}/bin


### PR DESCRIPTION
Add master based LEDE branch that is needed for using more current builders based on LEDE master as stable does not support newly added Mikrotik devices to Nodewatcher.

Also added rbcfg and vnstat packages and merger MT7628 and MT7688 targets to MT76x8 as per LEDE.