### PR TITLE
Rebrand back to Wlanslovenija

### DIFF
--- a/openwrt/docker/Dockerfile.runtime
+++ b/openwrt/docker/Dockerfile.runtime
@@ -1,1 +1,1 @@
-FROM otvorenamreza/firmware-runtime
+FROM wlanslovenija/firmware-runtime

--- a/openwrt/scripts/build
+++ b/openwrt/scripts/build
@@ -17,10 +17,10 @@ fi
 ./generate-dockerfiles ${openwrt_version} ${openwrt_target} ${openwrt_subtarget}
 
 # Prepare docker 18.04 based buildsystem
-docker build --rm -t otvorenamreza/firmware-base ${work_dir}/.
+docker build --rm -t wlanslovenija/firmware-base ${work_dir}/.
 
 # Start the building
-docker build --rm -t otvorenamreza/openwrt-imagebuilder-base:${openwrt_version}_${openwrt_target}_${openwrt_subtarget} ${docker_dir}/imagebuilder_base/${openwrt_version}/${openwrt_target}/${openwrt_subtarget}/.
+docker build --rm -t wlanslovenija/openwrt-imagebuilder-base:${openwrt_version}_${openwrt_target}_${openwrt_subtarget} ${docker_dir}/imagebuilder_base/${openwrt_version}/${openwrt_target}/${openwrt_subtarget}/.
 
 # Package the builder with runtime image
 ./docker-build-builders ${openwrt_version} ${openwrt_target} ${openwrt_subtarget}

--- a/openwrt/scripts/docker-build
+++ b/openwrt/scripts/docker-build
@@ -70,7 +70,7 @@ cd SDK
 export LC_ALL=C
 
 # Add Wlan SI OPKG feed
-echo "src-git wlansi https://github.com/robimarko/firmware-packages-opkg.git" >> feeds.conf.default
+echo "src-git wlansi https://github.com/wlanslovenija/firmware-packages-opkg.git" >> feeds.conf.default
 
 # Disable default options
 echo "# CONFIG_ALL_NONSHARED is not set" >> .config

--- a/openwrt/scripts/docker-build-builders
+++ b/openwrt/scripts/docker-build-builders
@@ -8,5 +8,5 @@ platform_dir="${work_dir}/openwrt"
 
 echo "Creating runtime Docker container for ${openwrt_version} ${openwrt_target} ${openwrt_subtarget}"
 
-docker run --rm otvorenamreza/openwrt-imagebuilder-base:${openwrt_version}_${openwrt_target}_${openwrt_subtarget} 2>/dev/null | \
+docker run --rm wlanslovenija/openwrt-imagebuilder-base:${openwrt_version}_${openwrt_target}_${openwrt_subtarget} 2>/dev/null | \
 docker build --rm --force-rm -t wlanslovenija/openwrt-builder:${openwrt_version}_${openwrt_target}_${openwrt_subtarget} - >/dev/null 2>/dev/null


### PR DESCRIPTION
A lot of images were otvorenamreza tagged since they were not yet being built by Docker Hub.
No need for that now,so re brand all of otvorenamreza to wlanslovenija.

Also use wlanslovenija package repo again since it is now synced with mine.