### PR TITLE
openwrt: Correct wrong Docker image name

### DIFF
--- a/openwrt/scripts/generate-dockerfiles
+++ b/openwrt/scripts/generate-dockerfiles
@@ -9,7 +9,7 @@ template_imagebuilder_base="
 # WARNING: This is an automatically generated Dockerfile. DO NOT EDIT. #
 ########################################################################
 
-FROM otvorenamreza/firmware-base
+FROM wlanslovenija/firmware-base
 
 RUN mkdir -p /buildsystem/build && \\\\
  chown -R builder:builder /buildsystem/build && \\\\


### PR DESCRIPTION
While rebranding back to Wlanslovenija I forgot to change the image name in generate-dockerfiles script.
So fix that